### PR TITLE
Add functional_dependency test

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,27 @@ models:
                 where: "num_orders > 0"
 ```
 
+### functional_dependency ([source](macros/generic_tests/functional_dependency.sql))
+
+This test confirms that a particular column is *functionally dependent* on one or more other columns. That is, for each distinct combination of those other columns, there should be no more than one distinct value in our particular column.
+
+This test is often useful for denormalized source data, where logical relationships between fields are implicitly expected but don't always hold, due to manual entry errors, or merges from different systems. Broken functional dependencies often surface as dupes and other anomalies downstream.
+
+*Common misunderstanding*: Functional dependency is *not* uniqueness. Functional dependency checks there is at most one distinct value (in each group), but allows that value to appear many times. Uniqueness allows many distinct values, but checks each value appears only once.
+
+**Usage:**
+
+```yaml
+models:
+  - name: orders
+    columns:
+      - name: customer_name
+        tests:
+        - dbt_utils.functional_dependency:
+            depends_on:
+              - customer_id
+```
+
 ----
 
 ### Grouping in tests

--- a/integration_tests/data/schema_tests/data_test_functional_dependency.csv
+++ b/integration_tests/data/schema_tests/data_test_functional_dependency.csv
@@ -1,0 +1,6 @@
+order_id,customer_id,customer_name
+1001,1,Ash
+1002,2,Brock
+1003,2,Brock
+1004,3,Ash
+1005,4,

--- a/integration_tests/data/schema_tests/schema.yml
+++ b/integration_tests/data/schema_tests/schema.yml
@@ -19,3 +19,14 @@ seeds:
           - dbt_utils.sequential_values:
               interval: 1
               datepart: 'hour'
+
+
+  - name: data_test_functional_dependency
+    columns:
+      - name: order_id
+      - name: customer_id
+      - name: customer_name
+        data_tests:
+          - dbt_utils.functional_dependency:
+              depends_on:
+                - customer_id

--- a/macros/generic_tests/functional_dependency.sql
+++ b/macros/generic_tests/functional_dependency.sql
@@ -1,0 +1,39 @@
+{% test functional_dependency(model, column_name, depends_on, quote_columns=False) %}
+  {{ return(adapter.dispatch('test_functional_dependency', 'dbt_utils')(model, column_name, depends_on, quote_columns)) }}
+{% endtest %}
+
+
+{% macro default__test_functional_dependency(model, column_name, depends_on, quote_columns=False) %}
+
+
+{% if not quote_columns %}
+    {%- set column_list=depends_on %}
+{% elif quote_columns %}
+    {%- set column_list=[] %}
+        {%- for column in depends_on %}
+            {%- set column_list = column_list.append( adapter.quote(column) ) %}
+        {%- endfor %}
+{% else %}
+    {{ exceptions.raise_compiler_error(
+        "`quote_columns` argument for functional_dependency test must be one of [True, False]"
+    ) }}
+{% endif %}
+
+
+{%- set columns_csv=column_list | join(', ') %}
+
+
+with validation_errors as (
+
+    select {{ columns_csv }}
+    from {{ model }}
+    group by {{ columns_csv }}
+    having count(distinct {{ column_name }}) > 1
+
+)
+
+select *
+from validation_errors
+
+
+{% endmacro %}


### PR DESCRIPTION
Resolves issue 1020

### Problem

**There is no functional dependency test**.

A particular column is [functionally dependent](https://en.wikipedia.org/wiki/Functional_dependency#Employee_department) on one or more other columns if for each distinct combination of those other columns, there should be no more than one distinct value in our column.

This test is often useful for denormalized source data, where logical relationships between fields are implicitly expected but don't always hold, due to manual entry errors, or merges from different systems. Broken functional dependencies often surface as dupes and other anomalies downstream.

*Common misunderstanding*: Functional dependency is *not* uniqueness. Functional dependency checks there is at most one distinct value (in each group), but allows that value to appear many times. Uniqueness allows many distinct values, but checks each value appears only once.

### Solution

**Add a functional_dependency generic test**.

See issue 1020.

This implementation is modeled on PR 177, which introduced another generic test.

### Usage

```yaml
models:
  - name: orders
    columns:
      - name: customer_name
        tests:
        - dbt_utils.functional_dependency:
            depends_on:
              - customer_id
```

### File Changes

Implement the new generic test  
`macros/generic_tests/functional_dependency.sql`

Define integration tests using the dbt-utils testing framework  
`integration_tests/data/schema_tests/data_test_functional_dependency.csv`  
`integration_tests/data/schema_tests/schema.yml`

Add a description and usage example for the new test  
`README.md`

## Checklist
- [x]  This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
